### PR TITLE
fix: バグ タスク名でスペースを入れると消滅する

### DIFF
--- a/handler/discord_handler.go
+++ b/handler/discord_handler.go
@@ -244,9 +244,9 @@ func HandleEdit(s *discordgo.Session, m *discordgo.MessageCreate, content string
 			newPriority = nil
 		}
 	} else if len(params) == 2 { // !edit <num> <title> <priority>
-		if pid, ok := priorityMap[params[0]]; ok { // priority
+		if pid, ok := priorityMap[params[1]]; ok { // priority
 			newPriority = &pid
-			newTitle = params[1]
+			newTitle = params[0]
 		} else {
 			replyToUser(s, m.ChannelID, m.Author.ID, "```❌ 優先度の形式が正しくありません```")
 			return

--- a/handler/discord_handler.go
+++ b/handler/discord_handler.go
@@ -247,6 +247,9 @@ func HandleEdit(s *discordgo.Session, m *discordgo.MessageCreate, content string
 		if pid, ok := priorityMap[params[0]]; ok { // priority
 			newPriority = &pid
 			newTitle = params[1]
+		} else {
+			replyToUser(s, m.ChannelID, m.Author.ID, "```❌ 優先度の形式が正しくありません```")
+			return
 		}
 	}
 


### PR DESCRIPTION
優先度の形式が誤っていた際の対応漏れ
- fix: #16