### PR TITLE
Fix index validation in UpdateTaskService

### DIFF
--- a/service/task_service.go
+++ b/service/task_service.go
@@ -22,6 +22,9 @@ func UpdateTaskService(userID string, TaskNumber int, title string, priorityID *
 	if len(tasks) == 0 {
 		return fmt.Errorf("タスクが1件も登録されていません")
 	}
+	if TaskNumber < 0 || TaskNumber >= len(tasks) {
+		return fmt.Errorf("指定されたタスク番号は存在しません")
+	}
 	return repository.UpdateTask(tasks[TaskNumber].ID, title, priorityID)
 }
 func CompleteTaskService(userID string, DoneTaskNumber int) error {


### PR DESCRIPTION
## Summary
- catch out of range indices in `UpdateTaskService`

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684813fd0154833294571c2fb01a1f5a