### PR TITLE
fix: ユーザーコマンド処理時はContentからメンション部分をパースしたものを使う

### DIFF
--- a/handler/discord_handler.go
+++ b/handler/discord_handler.go
@@ -2,11 +2,12 @@ package handler
 
 import (
 	"fmt"
-	"github.com/bwmarrin/discordgo"
 	"self-management-bot/service"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/bwmarrin/discordgo"
 )
 
 var resetAllConfirm = make(map[string]time.Time)
@@ -37,7 +38,7 @@ func MessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
-	content := strings.TrimSpace(m.Content)
+	content := strings.TrimSpace(m.ContentWithMentionsReplaced())
 
 	switch {
 	case strings.HasPrefix(content, "!add "):


### PR DESCRIPTION
## Before / After
<img width="795" height="288" alt="image" src="https://github.com/user-attachments/assets/e818dbe7-ae9b-484f-a720-b32bb7b5f691" />


