### PR TITLE
feat: pretty err log

### DIFF
--- a/handler/discord_handler.go
+++ b/handler/discord_handler.go
@@ -10,6 +10,8 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+const COMMAND_PREFIX = "!"
+
 var resetAllConfirm = make(map[string]time.Time)
 
 // 優先度チェック
@@ -41,29 +43,29 @@ func MessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	content := strings.TrimSpace(m.ContentWithMentionsReplaced())
 
 	switch {
-	case strings.HasPrefix(content, "!add "):
+	case strings.HasPrefix(content, fmt.Sprintf("%sadd ", COMMAND_PREFIX)):
 		HandleAdd(s, m, content)
-	case strings.HasPrefix(content, "!list"):
+	case strings.HasPrefix(content, fmt.Sprintf("%slist", COMMAND_PREFIX)):
 		HandleList(s, m)
-	case strings.HasPrefix(content, "!done "):
+	case strings.HasPrefix(content, fmt.Sprintf("%sdone ", COMMAND_PREFIX)):
 		HandleComplete(s, m, content)
-	case strings.HasPrefix(content, "!delete"):
+	case strings.HasPrefix(content, fmt.Sprintf("%sdelete", COMMAND_PREFIX)):
 		HandleDelete(s, m, content)
-	case strings.HasPrefix(content, "!chat "):
+	case strings.HasPrefix(content, fmt.Sprintf("%schat ", COMMAND_PREFIX)):
 		HandleChat(s, m, content)
-	case strings.HasPrefix(content, "!reset"):
+	case strings.HasPrefix(content, fmt.Sprintf("%sreset", COMMAND_PREFIX)):
 		HandleReset(s, m)
-	case strings.HasPrefix(content, "!confirm reset"):
+	case strings.HasPrefix(content, fmt.Sprintf("%sconfirm reset", COMMAND_PREFIX)):
 		HandleConfirm(s, m)
-	case strings.HasPrefix(content, "!edit "):
+	case strings.HasPrefix(content, fmt.Sprintf("%sedit ", COMMAND_PREFIX)):
 		HandleEdit(s, m, content)
-	case strings.HasPrefix(content, "!help"):
+	case strings.HasPrefix(content, fmt.Sprintf("%shelp", COMMAND_PREFIX)):
 		HandleHelp(s, m)
 	}
 }
 
 func HandleAdd(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
-	args := strings.Fields(strings.TrimPrefix(content, "!add"))
+	args := strings.Fields(strings.TrimPrefix(content, fmt.Sprintf("%sadd", COMMAND_PREFIX)))
 	if len(args) == 0 {
 		replyToUser(s, m.ChannelID, m.Author.ID, "```⚠️ タスク内容を追加してください```")
 		return
@@ -116,7 +118,7 @@ func HandleList(s *discordgo.Session, m *discordgo.MessageCreate) {
 }
 
 func HandleComplete(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
-	arg := strings.TrimPrefix(content, "!done ")
+	arg := strings.TrimPrefix(content, fmt.Sprintf("%sdone ", COMMAND_PREFIX))
 	DoneTaskNumber, err := strconv.Atoi(arg)
 	if err != nil {
 		replyToUser(s, m.ChannelID, m.Author.ID, "```❌ 数字を指定してください```")
@@ -154,7 +156,7 @@ func HandleComplete(s *discordgo.Session, m *discordgo.MessageCreate, content st
 }
 
 func HandleDelete(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
-	arg := strings.TrimPrefix(content, "!delete ")
+	arg := strings.TrimPrefix(content, fmt.Sprintf("%sdelete ", COMMAND_PREFIX))
 	DeleteNumber, err := strconv.Atoi(arg)
 	if err != nil {
 		replyToUser(s, m.ChannelID, m.Author.ID, "```❌ 数字を指定してください```")
@@ -169,7 +171,7 @@ func HandleDelete(s *discordgo.Session, m *discordgo.MessageCreate, content stri
 }
 
 func HandleChat(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
-	arg := strings.TrimPrefix(content, "!chat ")
+	arg := strings.TrimPrefix(content, fmt.Sprintf("%schat ", COMMAND_PREFIX))
 	if len(strings.TrimSpace(arg)) == 0 {
 		replyToUser(s, m.ChannelID, m.Author.ID, "```❌ メッセージを入力してください```")
 		return
@@ -187,7 +189,7 @@ func HandleChat(s *discordgo.Session, m *discordgo.MessageCreate, content string
 }
 
 func HandleReset(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if strings.HasPrefix(m.Content, "!reset all") {
+	if strings.HasPrefix(m.Content, fmt.Sprintf("%sreset all", COMMAND_PREFIX)) {
 		resetAllConfirm[m.Author.ID] = time.Now().Add(10 * time.Minute)
 		replyToUser(s, m.ChannelID, m.Author.ID,
 			"```⚠️ 本当に全タスク（過去含む）を削除しますか？\n削除するには '!confirm reset' と入力してください。（10分以内）```")
@@ -220,7 +222,7 @@ func HandleConfirm(s *discordgo.Session, m *discordgo.MessageCreate) {
 }
 
 func HandleEdit(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
-	arg := strings.TrimPrefix(content, "!edit ")
+	arg := strings.TrimPrefix(content, fmt.Sprintf("%sedit ", COMMAND_PREFIX))
 	fields := strings.Fields(arg)
 	if len(fields) < 2 {
 		replyToUser(s, m.ChannelID, m.Author.ID, fmt.Sprintf("```⚠️ コマンドの形式が正しくありません。\n例: `!edit 1 <title/優先度>` or `!edit 1 title 優先度` ```"))

--- a/internal/errors/apperror.go
+++ b/internal/errors/apperror.go
@@ -1,0 +1,38 @@
+package errors
+
+import (
+	"fmt"
+)
+
+type AppError struct {
+	Name string
+	Err  error // wrap 元
+}
+
+func (e *AppError) Error() string {
+	if e == nil {
+		return ""
+	}
+	err := e.Err
+	if err == nil {
+		return fmt.Sprintf("[%s]: unknown error", e.Name)
+	}
+	errMsg := err.Error()
+	if len(errMsg) >= 1 && errMsg[0] == '[' {
+		return fmt.Sprintf("[%s]%s", e.Name, errMsg)
+	}
+
+	return fmt.Sprintf("[%s]: %s", e.Name, errMsg)
+}
+
+func NewAppError(name string, err error) *AppError {
+	if err == nil {
+		return nil
+	}
+	return &AppError{
+		Name: name,
+		Err:  err,
+	}
+}
+
+func (e *AppError) Unwrap() error { return e.Err }


### PR DESCRIPTION
# やった
- [refactor: debugしやすいようにprefixを変数で切り替えられるようにする](https://github.com/cercil0605/self-management-bot-layerd/commit/aca467eacb592c719e2af74428163851996f0682)
- [feat: pretty error log](https://github.com/cercil0605/self-management-bot-layerd/commit/5448715a761d9f34b6abd05d23c4aca9f5a930fc)
- Fix: #33 

# 結果
```
app-1  | ⏳ Waiting for database at db:5432 ...
app-1  | ✅ DB is ready.
app-1  | 🚀 Running migrations...
app-1  | no change
app-1  | 🏁 Starting app...
app-1  | 2025/09/29 00:21:53 ✅ DB 初期化成功
app-1  | 2025/09/29 00:21:53 ✅ Discordセッション成功
app-1  | 2025/09/29 00:21:54 ✅ Discord接続成功
app-1  | 2025/09/29 00:21:54 ✅ Bot is now running... 
app-1  | 2025/09/29 00:21:55 ❌ [MessageCreate][HandleConfirm][expired]: confirmation expired
app-1  | 2025/09/29 00:22:12 ❌ [MessageCreate][HandleChat][ChatWithContext]: generate: Error 400, Message: API key not valid. Please pass a valid API key., Status: INVALID_ARGUMENT, Details: [map[@type:type.googleapis.com/google.rpc.ErrorInfo domain:googleapis.com metadata:map[service:generativelanguage.googleapis.com] reason:API_KEY_INVALID] map[@type:type.googleapis.com/google.rpc.LocalizedMessage locale:en-US message:API key not valid. Please pass a valid API key.]]
app-1  | 2025/09/29 00:22:19 ❌ [MessageCreate][HandleEdit][invalidFormat]: invalid command format
```